### PR TITLE
Add two fixes for retryable client and boost timeout deadline

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -135,6 +135,9 @@ func awsRetry(req *http.Request, res *http.Response, err error) bool {
 	}
 
 	// Check the body to see if it matches ContentLength
+	// XXX This is a temporary hack to work around an issue where
+	// it appears deadline is triggering a timeout without returning a
+	// timeout error.
 	if res.ContentLength > 0 && res.Body != nil {
 		body, _ := ioutil.ReadAll(res.Body)                // Read the body
 		res.Body = ioutil.NopCloser(bytes.NewReader(body)) // Restore the reader


### PR DESCRIPTION
1. When retrying a request that has a body, the first attempt would
   possibly read some of the body and so the reader would not be at
   the beginning. This resulted in requests being sent with an empty body.
   To fix this, we now make a copy of the body and reset the reader on
   every retry.
2. For an unknown reason, our deadline would cause a timeout without a
   timeout error being returned. This resulted in an empty response body
   despite the contentLength reporting bytes. We now check contentLength vs
   the body length and treat a mismatch as a retryable error.

@vgarg 
