### PR TITLE
Add support for leveled logging. Add key log statements

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -15,15 +15,16 @@ import (
 	"encoding/hex"
 	"encoding/xml"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/czos/goamz/aws"
 )
 
@@ -138,20 +139,21 @@ func (ec2 *EC2) query(params map[string]string, resp interface{}) error {
 	}
 	sign(ec2.Auth, "GET", endpoint.Path, params, endpoint.Host)
 	endpoint.RawQuery = multimap(params).Encode()
-	if debug {
-		log.Printf("get { %v } -> {\n", endpoint.String())
-	}
+	log.Debugf("GET %v", endpoint.String())
 	r, err := ec2.httpClient.Get(endpoint.String())
 	if err != nil {
 		return err
 	}
 	defer r.Body.Close()
 
-	if debug {
-		dump, _ := httputil.DumpResponse(r, true)
-		log.Printf("response:\n")
-		log.Printf("%v\n}\n", string(dump))
+	dump := []byte{}
+	if tracingEnabled() {
+		dump, _ = httputil.DumpResponse(r, true)
+	} else {
+		dump, _ = httputil.DumpResponse(r, false)
 	}
+	log.Debugf("%v\n", string(dump))
+
 	if r.StatusCode != 200 {
 		return buildError(r)
 	}
@@ -1899,4 +1901,12 @@ func (ec2 *EC2) DescribeAvailabilityZones(filter *Filter) (resp *DescribeAvailab
 		return nil, err
 	}
 	return
+}
+
+func tracingEnabled() bool {
+	t, err := strconv.ParseBool(os.Getenv("TRACE"))
+	if err != nil {
+		return false
+	}
+	return t
 }


### PR DESCRIPTION
The change imports the logrus leveled logger to logrus logger into the ec2 and aws packages. It also introduces log statements at key locations to enable request and response tracking.

@wes-r please review.