### PR TITLE
Support timeout based retry

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -76,7 +76,7 @@ var retryingTransport = &ResilientTransport{
 		return time.Now().Add(10 * time.Second)
 	},
 	DialTimeout:     10 * time.Second,
-	ShouldRetry:     awsRetry,
+	ShouldRetry:     AwsRetry,
 	Wait:            ExpBackoff,
 	MaxRetryWait:    10 * time.Second,
 	MinRetryWait:    100 * time.Millisecond,
@@ -147,7 +147,7 @@ func LinearBackoff(try int) {
 // Decide if we should retry a request.
 // In general, the criteria for retrying a request is described here
 // http://docs.aws.amazon.com/general/latest/gr/api-retries.html
-func awsRetry(req *http.Request, res *http.Response, err error) bool {
+func AwsRetry(req *http.Request, res *http.Response, err error) bool {
 	// Retry if there's a temporary network error.
 	if neterr, ok := err.(net.Error); ok {
 		if neterr.Temporary() {

--- a/aws/client.go
+++ b/aws/client.go
@@ -193,23 +193,27 @@ func AwsRetry(req *http.Request, res *http.Response, err error) bool {
 }
 
 func logRequest(req *http.Request) {
-	log.Debugf("%s %v", req.Method, req.URL.String())
+	level := traceLevel()
+	if level >= 1 {
+		log.Debugf("%s %v", req.Method, req.URL.String())
+	}
 }
 
 func logResponse(res *http.Response) {
-	dump := []byte{}
-	if tracingEnabled() {
-		dump, _ = httputil.DumpResponse(res, true)
-	} else {
-		dump, _ = httputil.DumpResponse(res, false)
+	level := traceLevel()
+	if level == 1 {
+		dump, _ := httputil.DumpResponse(res, false)
+		log.Debugf("%v", string(dump))
+	} else if level == 2 {
+		dump, _ := httputil.DumpResponse(res, true)
+		log.Debugf("%v", string(dump))
 	}
-	log.Debugf("%v", string(dump))
 }
 
-func tracingEnabled() bool {
-	t, err := strconv.ParseBool(os.Getenv("TRACE"))
+func traceLevel() int64 { // TODO: replace with glog
+	t, err := strconv.ParseInt(os.Getenv("TRACE"), 10, 0)
 	if err != nil {
-		return false
+		return 0
 	}
 	return t
 }

--- a/aws/client_test.go
+++ b/aws/client_test.go
@@ -2,13 +2,14 @@ package aws_test
 
 import (
 	"fmt"
-	"github.com/czos/goamz/aws"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/czos/goamz/aws"
 )
 
 // Retrieve the response from handler using aws.RetryingClient
@@ -106,6 +107,7 @@ func TestClient_retries(t *testing.T) {
 }
 
 func TestClient_fails(t *testing.T) {
+	start := time.Now()
 	tries := 0
 	// Fail 3 times and return the last error.
 	_, err := serveAndGet(func(w http.ResponseWriter, r *http.Request) {
@@ -115,7 +117,8 @@ func TestClient_fails(t *testing.T) {
 	if err == nil {
 		t.Fatal(err)
 	}
-	if tries != 3 {
+	end := time.Now()
+	if end.Sub(start).Seconds() < 60 { // checking the default value
 		t.Fatal("Didn't retry enough")
 	}
 }

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -15,15 +15,16 @@ import (
 	"encoding/hex"
 	"encoding/xml"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/czos/goamz/aws"
 )
 
@@ -138,20 +139,21 @@ func (ec2 *EC2) query(params map[string]string, resp interface{}) error {
 	}
 	sign(ec2.Auth, "GET", endpoint.Path, params, endpoint.Host)
 	endpoint.RawQuery = multimap(params).Encode()
-	if debug {
-		log.Printf("get { %v } -> {\n", endpoint.String())
-	}
+	log.Debugf("GET %v", endpoint.String())
 	r, err := ec2.httpClient.Get(endpoint.String())
 	if err != nil {
 		return err
 	}
 	defer r.Body.Close()
 
-	if debug {
-		dump, _ := httputil.DumpResponse(r, true)
-		log.Printf("response:\n")
-		log.Printf("%v\n}\n", string(dump))
+	dump := []byte{}
+	if tracingEnabled() {
+		dump, _ = httputil.DumpResponse(r, true)
+	} else {
+		dump, _ = httputil.DumpResponse(r, false)
 	}
+	log.Debugf("%v\n", string(dump))
+
 	if r.StatusCode != 200 {
 		return buildError(r)
 	}
@@ -1899,4 +1901,12 @@ func (ec2 *EC2) DescribeAvailabilityZones(filter *Filter) (resp *DescribeAvailab
 		return nil, err
 	}
 	return
+}
+
+func tracingEnabled() bool {
+	t, err := strconv.ParseBool(os.Getenv("TRACE"))
+	if err != nil {
+		return false
+	}
+	return t
 }


### PR DESCRIPTION
The AWS RetryingHttpClient currently supports retrying upon network errors and server errors for a fixed number of re-tries. With this approach, especially with exponential backoff, it is hard to know in total for how long requests may be re-tried. It is more useful to be able to say that a request should be re-tried upon error for 120 seconds

This pull request changes the client.go implementation to support a time duration as the retry timeout. In addition it also exposes the min and max wait durations for finer control.

The changes keep sane defaults. Clients are expected to create their own ResilientTransport instances to tweak various timeouts and behaviors.

This change depends on another Pull Request #6 for supporting leveled logging.

@wes-r please review.