### PR TITLE
Include x-amz-security-token header. Pass Number of nodes only if >1

### DIFF
--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -80,6 +80,10 @@ func (rs *Redshift) query(params map[string]string, resp interface{}) error {
 		return err
 	}
 	req.Header.Add("X-Amz-Date", time.Now().UTC().Format(aws.ISO8601BasicFormat))
+	if rs.Auth.Token() != "" {
+		req.Header.Add("X-Amz-Security-Token",
+			time.Now().UTC().Format(aws.ISO8601BasicFormat))
+	}
 
 	// sign the request
 	signer := aws.NewV4Signer(rs.Auth, "redshift", rs.Region)

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -81,8 +81,7 @@ func (rs *Redshift) query(params map[string]string, resp interface{}) error {
 	}
 	req.Header.Add("X-Amz-Date", time.Now().UTC().Format(aws.ISO8601BasicFormat))
 	if rs.Auth.Token() != "" {
-		req.Header.Add("X-Amz-Security-Token",
-			time.Now().UTC().Format(aws.ISO8601BasicFormat))
+		req.Header.Add("X-Amz-Security-Token", rs.Auth.Token())
 	}
 
 	// sign the request

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -428,10 +428,6 @@ func (rs *Redshift) CreateCluster(
 		params["ClusterSubnetGroupName"] = options.ClusterSubnetGroupName
 	}
 
-	if options.ClusterType != "" {
-		params["ClusterType"] = options.ClusterType
-	}
-
 	if options.ClusterVersion != "" {
 		params["ClusterVersion"] = options.ClusterVersion
 	}
@@ -461,7 +457,14 @@ func (rs *Redshift) CreateCluster(
 		params["KmsKeyId"] = options.KmsKeyId
 	}
 
-	params["NumberOfNodes"] = strconv.Itoa(options.NumberOfNodes)
+	if options.ClusterType != "" {
+		params["ClusterType"] = options.ClusterType
+	}
+
+	if options.NumberOfNodes > 1 {
+		params["NumberOfNodes"] = strconv.Itoa(options.NumberOfNodes)
+	}
+
 	params["Port"] = strconv.Itoa(options.Port)
 
 	if options.PreferredMaintenanceWindow != "" {


### PR DESCRIPTION
Fixes two issues:

Redshift auth require that x-amz-security-token header is supplied in cases where temporary credentials are used.
The NumberOfNodes parameter should only be supplied if >1